### PR TITLE
fix: documentation linting and clarity improvements

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -9,7 +9,7 @@
 ## Architecture & Key Modules
 - Plugin hooks into NetBox (Django 5) under `netbox_librenms_plugin/`; respect NetBox plugin APIs (`navigation.py`, `urls.py`, `api/`).
 - LibreNMS communication lives in `librenms_api.py`; reuse this client instead of new `requests` calls. It handles multi-server configs via `LibreNMSSettings` model and the `servers` plugin config, plus caching via Django cache + custom fields.
-- Views follow a three-layer structure:
+- Views follow a four-layer structure:
   - **Base views** (`views/base/`) — abstract views for each sync resource (`BaseInterfaceTableView`, `BaseCableTableView`, `BaseIPAddressTableView`, `BaseVLANTableView`).
   - **Object sync views** (`views/object_sync/`) — concrete per-model views registered as tabs on NetBox's Device/VM detail pages via `@register_model_view(Device, ...)`. These wire base views to models.
   - **Sync action views** (`views/sync/`) — POST-only views that apply changes (add/change/delete NetBox objects). Includes `interfaces.py`, `cables.py`, `ip_addresses.py`, `vlans.py`, `devices.py`, `device_fields.py`, `locations.py`.

--- a/.github/instructions/background-jobs.instructions.md
+++ b/.github/instructions/background-jobs.instructions.md
@@ -6,10 +6,12 @@ description: Background job architecture, import workflow, and task management p
 # Background Jobs & Import Workflow
 
 ## Job Architecture
+
 - Background jobs use NetBox's `JobRunner` base class (`netbox.jobs.JobRunner`) for long-running operations like device filtering with VC detection.
 - Jobs run via Redis Queue (RQ) in Redis, separate from the database Job model. Real-time status must be checked via RQ, not the database.
 
 ## Critical Job Architecture Points
+
 - Job UUID (`job.job_id`) is used for RQ API endpoints: `/api/core/background-tasks/{uuid}/`
 - Job PK (`job.pk`) is used for database endpoints and result loading
 - RQ status values: `queued`, `started`, `finished`, `stopped`, `failed` (NOT `completed`)
@@ -17,41 +19,49 @@ description: Background job architecture, import workflow, and task management p
 - Check `rq_job.is_stopped` or `rq_job.is_failed` flags in Redis for cancellation detection, not database status
 
 ## Job Cancellation Flow
+
 1. Call `/api/core/background-tasks/{uuid}/stop/` to stop RQ job
 2. Call plugin's sync endpoint `/api/plugins/librenms_plugin/jobs/{pk}/sync-status/` to update database
 3. Frontend polling detects status changes and redirects appropriately
 
 ## Polling Implementation
+
 - Poll `/api/core/background-tasks/{uuid}/` for real-time RQ status
 - Update modal messages based on status: "Job queued...", "Processing...", "Job completed!"
 - Handle all RQ status values explicitly to avoid infinite polling
 - Use `cancelInProgress` flag to prevent polling interference during cancellation
 
 ## Superuser Requirement for Background Jobs
+
 - NetBox's `/api/core/background-tasks/` endpoint requires **superuser** (`IsSuperuser` in `BaseRQViewSet`).
 - Non-superuser users cannot poll job status; they get 403 Forbidden.
 - The plugin automatically falls back to synchronous mode for non-superusers—see `should_use_background_job()` in `list.py` and `actions.py`.
 - This is a NetBox core design decision, not a plugin limitation. No amount of permissions (including `core.view_job`) bypasses it.
 
 ## Import Jobs
+
 - **`FilterDevicesJob`** — background device filtering with VC detection. `job.data` keys: `device_ids`, `total_processed`, `filters`, `server_key`, `vc_detection_enabled`, `cache_timeout`, `cached_at`, `completed`. Devices are cached individually via shared cache keys from `get_validated_device_cache_key()`.
 - **`ImportDevicesJob`** — background device/VM import. Calls `bulk_import_devices_shared()` for devices and `bulk_import_vms()` for VMs. `job.data` keys: `imported_device_pks`, `imported_vm_pks`, `imported_libre_device_ids`, `imported_libre_vm_ids`, `server_key`, `total`, `success_count`, `failed_count`, `skipped_count`, `virtual_chassis_created`, `errors`, `completed`.
 
 ## Shared Cache Key Pattern
+
 - Both synchronous and background modes use `get_validated_device_cache_key()` from `import_utils.py` to generate cache keys. This ensures `_load_job_results()` in the list view can retrieve devices regardless of which mode produced them.
 - `get_active_cached_searches()` manages multi-search cache to let users run and switch between searches.
 - Never hardcode cache key formats; always use the helper functions.
 
 ## Permission Checks in Jobs
+
 - Background jobs run outside view context, so they cannot use view mixins.
 - Use standalone helpers from `import_utils.py` for permission checks inside job code:
   - `check_user_permissions(user, permissions)` → `(bool, missing_list)`
   - `require_permissions(user, permissions, action_description)` — raises `PermissionDenied`.
 
 ## Custom Sync Endpoint
+
 `api/views.py::sync_job_status()` syncs database Job status with RQ job status, needed because NetBox worker doesn't always update DB when jobs stop before processing starts.
 
 ## Import Page Flow
+
 The import page (`LibreNMSImportView` in `views/imports/list.py`) supports two modes:
 
 1. **Synchronous** — calls `process_device_filters()` directly, renders results inline.
@@ -62,6 +72,7 @@ Result loading: `_load_job_results(job_id)` reads `job.data["device_ids"]`, reco
 Filter fields: `librenms_location`, `librenms_type`, `librenms_os`, `librenms_hostname`, `librenms_sysname`, `librenms_hardware`, `enable_vc_detection`, `show_disabled`, `exclude_existing`.
 
 ## Import Action Views (`views/imports/actions.py`)
+
 - **`DeviceImportHelperMixin`** — provides `get_validated_device_with_selections()` and `render_device_row()` for HTMX row rendering. Shared by update views.
 - **`BulkImportConfirmView`** (POST) — renders confirmation modal with selected device list. Returns `htmx/bulk_import_confirm.html`.
 - **`BulkImportDevicesView`** (POST) — executes import. Background mode enqueues `ImportDevicesJob`; sync mode calls `bulk_import_devices()` + `bulk_import_vms()` and returns OOB row swaps with `HX-Trigger: closeModal`.
@@ -70,6 +81,7 @@ Filter fields: `librenms_location`, `librenms_type`, `librenms_os`, `librenms_ho
 - **`DeviceRoleUpdateView`**, **`DeviceClusterUpdateView`**, **`DeviceRackUpdateView`** (POST) — per-device dropdown updates. Apply selection to validation state and return re-rendered row via `render_device_row()`.
 
 ## Key Import Utilities (`import_utils.py`)
+
 - `process_device_filters(filters, ...)` — fetches and validates devices from LibreNMS, returns list.
 - `validate_device_for_import(device, ...)` — core validation function, produces validation state dict.
 - `bulk_import_devices_shared(devices, user, ...)` — shared implementation between sync and background import.
@@ -78,6 +90,7 @@ Filter fields: `librenms_location`, `librenms_type`, `librenms_os`, `librenms_ho
 - Cache key functions: `get_validated_device_cache_key()`, `get_cache_metadata_key()`, `get_active_cached_searches()`, `get_import_device_cache_key()`.
 
 ## Validation Helpers (`import_validation_helpers.py`)
+
 Centralizes validation state mutation used by the role/cluster/rack update views:
 - `apply_role_to_validation()`, `apply_cluster_to_validation()`, `apply_rack_to_validation()` — update validation state when user selects a role/cluster/rack.
 - `remove_validation_issue()`, `recalculate_validation_status()` — maintain issue list and overall status.

--- a/.github/instructions/sync.instructions.md
+++ b/.github/instructions/sync.instructions.md
@@ -6,6 +6,7 @@ description: Sync page architecture, base views, and sync action patterns
 # Sync Pages
 
 ## Three-Layer View Architecture
+
 All four sync resources (interfaces, cables, IP addresses, VLANs) follow the same pattern:
 
 1. **Base views** (`views/base/`) — abstract classes that define the data pipeline:
@@ -24,6 +25,7 @@ All four sync resources (interfaces, cables, IP addresses, VLANs) follow the sam
    - Follow a consistent pattern: check permissions → read selected rows from POST → load cached data → apply changes in `transaction.atomic()` → redirect to sync tab.
 
 ## Data Pipeline (Base Views)
+
 Every base table view follows: **fetch → cache → compare → render**.
 
 - **Fetch:** Call LibreNMS API (e.g., `get_ports()`, `get_device_ips()`, `get_device_vlans()`).
@@ -32,6 +34,7 @@ Every base table view follows: **fetch → cache → compare → render**.
 - **Render:** Build a django-tables2 table, return a partial template (`_*_sync_content.html`).
 
 ## Sync Action View Pattern
+
 ```python
 class SyncSomeResourceView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, CacheMixin, View):
     required_object_permissions = {"POST": [("add", Model), ("change", Model)]}
@@ -47,6 +50,7 @@ class SyncSomeResourceView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin,
 ```
 
 ## Table Conventions (`tables/*.py`)
+
 - Tables define HTMX-enabled columns and checkboxes. Selection uses `ToggleColumn(attrs={"input": {"name": "select"}})`.
 - Constructor takes contextual params (e.g., `device`, `interface_name_field`, `vlan_groups`) to customize rendering.
 - Tables set `self.tab` and `self.prefix` for multi-table pagination via `get_table_paginate_count()`.
@@ -54,11 +58,13 @@ class SyncSomeResourceView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin,
 - VLAN columns use `render_vlans()` with hidden inputs for per-row group selection and JSON data for modals.
 
 ## Key Mixins Used by Sync Views
+
 - **`LibreNMSAPIMixin`** — lazy-creates `LibreNMSAPI` instance via `self.librenms_api` property. Also provides `get_server_info()` for template context.
 - **`CacheMixin`** — generates consistent cache keys via `get_cache_key(obj, data_type)` and `get_last_fetched_key(obj, data_type)`. Also provides `get_vlan_overrides_key(obj)` for VLAN group override persistence.
 - **`VlanAssignmentMixin`** — VLAN group scope resolution: Rack → Location → Site → SiteGroup → Region → Global. Used by interface and VLAN sync for auto-selecting the most-specific VLAN group and building lookup maps.
 
 ## JavaScript (`librenms_sync.js`)
+
 - Not wrapped in an IIFE — functions are global. Master initializer `initializeScripts()` runs on `DOMContentLoaded` and `htmx:afterSwap`.
 - **Key function groups:**
   - Checkbox management: `initializeTableCheckboxes()`, `updateBulkActionButton()`.

--- a/.github/instructions/testing.instructions.md
+++ b/.github/instructions/testing.instructions.md
@@ -6,6 +6,7 @@ description: Testing patterns and conventions for the NetBox LibreNMS plugin
 # Testing Patterns
 
 ## General Test Conventions
+
 - Use plain **pytest classes**, not Django `TestCase`. Avoid `from django.test import TestCase`.
 - **Never use `@pytest.mark.django_db`** for unit tests—mock all database interactions with `MagicMock`.
 - Use **inline imports** inside test methods to avoid Django initialization at module load time.
@@ -14,6 +15,7 @@ description: Testing patterns and conventions for the NetBox LibreNMS plugin
 - See [docs/development/testing.md](../../docs/development/testing.md) for test file structure and running instructions.
 
 ## Background Job Tests
+
 - Instantiate `JobRunner` subclasses using `object.__new__(JobClass)` to bypass `__init__`, then set `job.job = MagicMock()` and `job.logger = MagicMock()`. See `create_mock_job_runner()` helper in `tests/test_background_jobs.py`.
 - Patch deferred/inline imports at their **source** module (e.g., `netbox_librenms_plugin.import_utils.process_device_filters`), not the consuming module.
 - Patch `cache` where imported: `netbox_librenms_plugin.views.imports.list.cache`, not `django.core.cache.cache`.
@@ -22,10 +24,12 @@ description: Testing patterns and conventions for the NetBox LibreNMS plugin
 - Cache key tests must patch `get_validated_device_cache_key` from `import_utils.py`; never hardcode key formats like `job_123_device_1`.
 
 ## Test File Naming
+
 - Follow the `test_{module_name}.py` convention for new test files.
 - `test_netbox_librenms_plugin.py` is an empty placeholder — do not add tests there.
 
 ## Test Coverage by Module
+
 - `librenms_api.py` → `test_librenms_api.py`, `test_librenms_api_helpers.py`
 - `import_utils.py`, `import_validation_helpers.py`, `utils.py` → `test_import_utils.py`, `test_import_validation_helpers.py`, `test_utils.py`
 - `jobs.py`, `views/imports/list.py` → `test_background_jobs.py`
@@ -35,6 +39,7 @@ description: Testing patterns and conventions for the NetBox LibreNMS plugin
 - Views (`views/sync/`, `views/object_sync/`, `views/imports/actions.py`) — no dedicated test files yet. Test business logic via the utility modules they call, not via HTTP requests.
 
 ## Permission Test Patterns
+
 When testing permissions (see `test_permissions.py` for reference):
 - Create a mock view instance with `object.__new__(ViewClass)`, set `request = MagicMock()` with `request.user.has_perm.side_effect = lambda p: p in allowed_perms`.
 - For `NetBoxObjectPermissionMixin` tests, set `required_object_permissions` on the instance before calling `check_object_permissions()`.
@@ -42,6 +47,7 @@ When testing permissions (see `test_permissions.py` for reference):
 - For JSON variants (`require_all_permissions_json`), assert `isinstance(response, JsonResponse)` and check `response.status_code == 403`.
 
 ## Shared Fixtures (`conftest.py`)
+
 Reuse fixtures from `tests/conftest.py` instead of creating ad-hoc mocks:
 - **Configuration**: `mock_multi_server_config`, `mock_legacy_config`
 - **API client**: `mock_librenms_api`

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Create cable connection in NetBox from LibreNMS links data.
 Create IP address in NetBox from LibreNMS device IP data.
 
 ### VLAN Sync
+
 - Create VLAN objects in NetBox from LibreNMS device VLAN data
 - Per-VLAN group assignment with scope-aware auto-selection
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -54,6 +54,7 @@ Create cable connection in NetBox from LibreNMS links data.
 Create IP address in NetBox from LibreNMS device IP data.
 
 ### VLAN Sync
+
 - Create VLAN objects in NetBox from LibreNMS device VLAN data
 - Per-VLAN group assignment with scope-aware auto-selection
 

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -27,6 +27,7 @@ The test suite covers all major plugin functionality. Tests are organized by the
 | [test_import_validation_helpers.py](../../netbox_librenms_plugin/tests/test_import_validation_helpers.py) | Field validation for sites, roles, platforms, and device types |
 | [test_utils.py](../../netbox_librenms_plugin/tests/test_utils.py) | General utilities—name matching, speed conversion, and data formatting |
 | [test_background_jobs.py](../../netbox_librenms_plugin/tests/test_background_jobs.py) | Background job execution and view decision logic |
+| [test_permissions.py](../../netbox_librenms_plugin/tests/test_permissions.py) | Permission mixins, API permissions, and permission constants |
 | [test_vlan_sync.py](../../netbox_librenms_plugin/tests/test_vlan_sync.py) | VLAN sync—API fetching, comparison logic, CSS class utilities, and sync actions |
 | [test_interface_vlan_sync.py](../../netbox_librenms_plugin/tests/test_interface_vlan_sync.py) | Interface VLAN assignments—group resolution, mode detection, and per-interface VLAN assignment |
 

--- a/docs/usage_tips/README.md
+++ b/docs/usage_tips/README.md
@@ -61,7 +61,7 @@ For best results, align chassis member positions with interface naming patterns.
     - Review interface mappings indicated by the icons (🔗 shows a mapping is configured)
     - Check speed and type matches
     - Confirm member assignments for virtual chassis
-2. Exclude columns to exclude from interface sync
+2. Exclude columns from interface sync
     - Sync only the values you want to sync
 3. Sync VLANs first to ensure that VLANs are created in NetBox before syncing interfaces, allowing for proper VLAN assignments. Use the VLAN tab on the device sync page to create VLANs from LibreNMS data.
 

--- a/docs/usage_tips/suggested_workflow.md
+++ b/docs/usage_tips/suggested_workflow.md
@@ -50,8 +50,11 @@ Use the [Device Import](../librenms_import/overview.md) feature to bring devices
 - Enable Virtual Chassis detection only when importing stackable switches
 
 ## 6. Sync VLAN
+
 - Create VLAN objects in NetBox from LibreNMS device VLAN data
 - Per-VLAN group assignment with scope-aware auto-selection
+
+**Why before interfaces**: Syncing VLANs first ensures they exist in NetBox before interface sync, enabling proper tagged and untagged VLAN assignments on interfaces.
 
 ## 7. Sync Interfaces
 


### PR DESCRIPTION
- Fix markdown linting: add blank lines after headings (MD022)
- Fix "three-layer" -> "four-layer structure" in copilot instructions
- Fix "Exclude columns to exclude" -> "Exclude columns" phrasing
- Add test_permissions.py to test structure table
- Add context paragraph for VLAN sync section in suggested workflow

## Summary
Briefly describe what this PR does in plain English, and provide as much of the following information as possible.

## Motivation / Problem
What issue does this solve?
- Bug
- Feature
- Refactor
- Maintenance / cleanup

Link any related issues if applicable.

## Scope of Change
Tick all that apply:

- [ ] Sync/Import logic
- [ ] NetBox models / ORM
- [ ] LibreNMS API interaction
- [ ] Config / settings
- [ ] Web UI / templates
- [ ] Database migrations
- [ ] Tests
- [ ] Docs only
- Other (please descibe)?

## How Was This Tested?
Tick all that apply and describe briefly.

- [ ] Unit tests
- [ ] Manual testing
- [ ] Not tested (explain why)

### Manual Test Steps (if applicable)
1.
2.
3.

## Risk Assessment
- Does this change affect existing users?  
- Could this cause unintended imports / updates?

Explain briefly.

## Backwards Compatibility
- [ ] No breaking changes
- [ ] Breaking change (explain and document)

## Other Notes
Anything the maintainer(s) should pay particular attention to?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Enhanced VLAN sync workflow guidance with recommended sequencing before interface sync and clear rationale for the order.
  * Expanded background job system and import workflow documentation with detailed implementation patterns.
  * Updated testing instructions with comprehensive mocking strategies and fixture guidance.
  * Improved architecture documentation with updated four-layer structure and shared components description.
  * Refined interface sync documentation for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->