### PR TITLE
fix: pin CI actions and rename ruff hook id

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,17 +39,17 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@main
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           path: netbox-librenms-plugin
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@main
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Checkout NetBox
-        uses: actions/checkout@main
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: "netbox-community/netbox"
           path: netbox
@@ -64,7 +64,7 @@ jobs:
       - name: Set up configuration
         working-directory: netbox
         run: |
-          ln -s $(pwd)/../netbox-librenms-plugin/media/configuration.testing.py netbox/netbox/configuration.py
+          ln -s "$(pwd)/../netbox-librenms-plugin/media/configuration.testing.py" netbox/netbox/configuration.py
 
           python -m pip install --upgrade pip
           python -m pip install tblib

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: v0.14.13  # Use the latest version from https://github.com/astral-sh/ruff-pre-commit/releases
     hooks:
       # Run the linter
-      - id: ruff
+      - id: ruff-check
         args: [--fix]
       # Run the formatter
       - id: ruff-format


### PR DESCRIPTION
- Pin checkout/setup-python actions to v4/v5 (from @main)
- Quote $(pwd) in workflow shell commands
- Rename pre-commit hook id from ruff to ruff-check

## Summary
Briefly describe what this PR does in plain English, and provide as much of the following information as possible.

## Motivation / Problem
What issue does this solve?
- Bug
- Feature
- Refactor
- Maintenance / cleanup

Link any related issues if applicable.

## Scope of Change
Tick all that apply:

- [ ] Sync/Import logic
- [ ] NetBox models / ORM
- [ ] LibreNMS API interaction
- [ ] Config / settings
- [ ] Web UI / templates
- [ ] Database migrations
- [ ] Tests
- [ ] Docs only
- Other (please descibe)?

## How Was This Tested?
Tick all that apply and describe briefly.

- [ ] Unit tests
- [ ] Manual testing
- [ ] Not tested (explain why)

### Manual Test Steps (if applicable)
1.
2.
3.

## Risk Assessment
- Does this change affect existing users?  
- Could this cause unintended imports / updates?

Explain briefly.

## Backwards Compatibility
- [ ] No breaking changes
- [ ] Breaking change (explain and document)

## Other Notes
Anything the maintainer(s) should pay particular attention to?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pinned CI workflow action versions for greater build stability.
  * Added automated dependency updates for CI actions.
  * Updated linting hook identifier to improve pre-commit checks.
  * Fixed a minor CI script quoting issue to prevent path handling errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->