### PR TITLE
fix: devcontainer script hardening and cleanup

### DIFF
--- a/.devcontainer/scripts/diagnose.sh
+++ b/.devcontainer/scripts/diagnose.sh
@@ -4,6 +4,7 @@
 echo "🔍 DevContainer Startup Diagnostics"
 echo "=================================="
 
+PLUGIN_WS_DIR="${PLUGIN_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
 echo "📍 Current working directory: $(pwd)"
 echo "👤 Current user: $(whoami)"
 echo "🆔 User ID: $(id)"
@@ -27,18 +28,20 @@ echo "  - Redis: $(timeout 3 bash -c 'cat < /dev/null > /dev/tcp/redis/6379' 2>/
 echo ""
 echo "🗂️ File System:"
 echo "  - NetBox venv: $(test -f /opt/netbox/venv/bin/activate && echo 'Exists' || echo 'Missing')"
-echo "  - Plugin directory: $(test -d /workspaces/netbox-librenms-plugin && echo 'Exists' || echo 'Missing')"
-echo "  - Setup script: $(test -f /workspaces/netbox-librenms-plugin/.devcontainer/scripts/setup.sh && echo 'Exists' || echo 'Missing')"
-echo "  - Start script: $(test -f /workspaces/netbox-librenms-plugin/.devcontainer/scripts/start-netbox.sh && echo 'Exists' || echo 'Missing')"
-echo "  - Start script executable: $(test -x /workspaces/netbox-librenms-plugin/.devcontainer/scripts/start-netbox.sh && echo 'Yes' || echo 'No')"
-echo "  - Plugin config: $(test -f /workspaces/netbox-librenms-plugin/.devcontainer/plugin-config.py && echo 'Found' || echo 'Missing (using defaults)')"
+echo "  - Plugin directory: $(test -d "$PLUGIN_WS_DIR" && echo 'Exists' || echo 'Missing')"
+echo "  - Setup script: $(test -f "$PLUGIN_WS_DIR/.devcontainer/scripts/setup.sh" && echo 'Exists' || echo 'Missing')"
+echo "  - Start script: $(test -f "$PLUGIN_WS_DIR/.devcontainer/scripts/start-netbox.sh" && echo 'Exists' || echo 'Missing')"
+echo "  - Start script executable: $(test -x "$PLUGIN_WS_DIR/.devcontainer/scripts/start-netbox.sh" && echo 'Yes' || echo 'No')"
+echo "  - Plugin config: $(test -f "$PLUGIN_WS_DIR/.devcontainer/plugin-config.py" && echo 'Found' || echo 'Missing (using defaults)')"
 echo "  - NetBox config path: /opt/netbox/netbox/netbox/configuration.py"
 
 echo ""
 echo "🚀 Process Status:"
 if [ -f /tmp/netbox.pid ]; then
   PID=$(cat /tmp/netbox.pid)
-  if [ -n "$PID" ] && kill -0 "$PID" 2>/dev/null; then
+  if [ -z "$PID" ]; then
+    echo "  - NetBox server: PID file exists but is empty"
+  elif kill -0 "$PID" 2>/dev/null; then
     echo "  - NetBox server: Running (PID: $PID)"
   else
     echo "  - NetBox server: PID file exists but process not running"

--- a/.devcontainer/scripts/load-aliases.sh
+++ b/.devcontainer/scripts/load-aliases.sh
@@ -5,64 +5,221 @@
 
 export PATH="/opt/netbox/venv/bin:$PATH"
 export DEBUG="${DEBUG:-True}"
-PLUGIN_DIR="/workspaces/netbox-librenms-plugin"
+PLUGIN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
-alias netbox-run-bg="$PLUGIN_DIR/.devcontainer/scripts/start-netbox.sh --background"
-alias netbox-run="$PLUGIN_DIR/.devcontainer/scripts/start-netbox.sh"
+# Clean up empty CA bundle vars (Compose/devcontainer inject "" when host var is
+# unset, which breaks requests/curl).  When setup.sh has installed custom CAs
+# into the system trust store, point to it instead.
+for _ca_var in REQUESTS_CA_BUNDLE SSL_CERT_FILE CURL_CA_BUNDLE; do
+  _val="${!_ca_var}"
+  if [ -z "$_val" ]; then
+    if [ -f /etc/ssl/certs/ca-certificates.crt ]; then
+      declare -x "$_ca_var=/etc/ssl/certs/ca-certificates.crt"
+    else
+      unset "$_ca_var"
+    fi
+  fi
+done
+unset _ca_var _val
+
+# Load shared process management helpers
+if ! source "$PLUGIN_DIR/.devcontainer/scripts/process-helpers.sh"; then
+  printf '%s\n' "Failed to load process-helpers.sh" >&2
+  return 1
+fi
+
+netbox-run-bg() { "$PLUGIN_DIR/.devcontainer/scripts/start-netbox.sh" --background; }
+netbox-run()    { "$PLUGIN_DIR/.devcontainer/scripts/start-netbox.sh"; }
 
 # Robust stop command that kills both tracked and orphaned processes
-alias netbox-stop='echo "🛑 Stopping NetBox and RQ workers..."; \
-  if [ -f /tmp/netbox.pid ]; then \
-    PID=$(cat /tmp/netbox.pid 2>/dev/null); \
-    if [ -n "$PID" ] && kill -0 "$PID" 2>/dev/null; then \
-      kill "$PID" 2>/dev/null || kill -9 "$PID" 2>/dev/null; \
-      echo "   Stopped NetBox (PID: $PID)"; \
-    fi; \
-    rm -f /tmp/netbox.pid; \
-  fi; \
-  if [ -f /tmp/rqworker.pid ]; then \
-    PID=$(cat /tmp/rqworker.pid 2>/dev/null); \
-    if [ -n "$PID" ] && kill -0 "$PID" 2>/dev/null; then \
-      kill "$PID" 2>/dev/null || kill -9 "$PID" 2>/dev/null; \
-      echo "   Stopped RQ worker (PID: $PID)"; \
-    fi; \
-    rm -f /tmp/rqworker.pid; \
-  fi; \
-  if pgrep -f "python.*rqworker" >/dev/null 2>&1; then \
-    ORPHAN_COUNT=$(pgrep -cf "python.*rqworker" 2>/dev/null || echo 0); \
-    pkill -9 -f "python.*rqworker" 2>/dev/null; \
-    echo "   Killed $ORPHAN_COUNT orphaned RQ worker(s)"; \
-  fi; \
-  if pgrep -f "python.*runserver.*8000" >/dev/null 2>&1; then \
-    pkill -9 -f "python.*runserver.*8000" 2>/dev/null; \
-    echo "   Killed orphaned NetBox server(s)"; \
-  fi; \
-  echo "✅ All processes stopped"'
+netbox-stop() {
+  echo "🛑 Stopping NetBox and RQ workers..."
+  if [ -f /tmp/netbox.pid ]; then
+    local PID
+    PID=$(cat /tmp/netbox.pid 2>/dev/null)
+    if [ -n "$PID" ] && kill -0 "$PID" 2>/dev/null; then
+      if is_expected_pid "$PID" "python.*runserver.*8000"; then
+        graceful_kill_pid "$PID"
+        echo "   Stopped NetBox (PID: $PID)"
+      else
+        echo "   Skipping stale /tmp/netbox.pid (PID $PID is not NetBox runserver)"
+      fi
+    fi
+    rm -f /tmp/netbox.pid
+  fi
+  if [ -f /tmp/rqworker.pid ]; then
+    local PID
+    PID=$(cat /tmp/rqworker.pid 2>/dev/null)
+    if [ -n "$PID" ] && kill -0 "$PID" 2>/dev/null; then
+      if is_expected_pid "$PID" "python.*rqworker"; then
+        graceful_kill_pid "$PID"
+        echo "   Stopped RQ worker (PID: $PID)"
+      else
+        echo "   Skipping stale /tmp/rqworker.pid (PID $PID is not rqworker)"
+      fi
+    fi
+    rm -f /tmp/rqworker.pid
+  fi
+  if pgrep -f "python.*rqworker" >/dev/null 2>&1; then
+    local ORPHAN_COUNT
+    ORPHAN_COUNT=$(pgrep -cf "python.*rqworker" 2>/dev/null || echo 0)
+    graceful_kill_pattern "python.*rqworker"
+    echo "   Killed $ORPHAN_COUNT orphaned RQ worker(s)"
+  fi
+  if pgrep -f "python.*runserver.*8000" >/dev/null 2>&1; then
+    graceful_kill_pattern "python.*runserver.*8000"
+    echo "   Killed orphaned NetBox server(s)"
+  fi
+  echo "✅ All processes stopped"
+}
 
-alias netbox-restart="netbox-stop && sleep 1 && netbox-run-bg"
-alias netbox-reload="cd $PLUGIN_DIR && (command -v uv >/dev/null 2>&1 && uv pip install -e . || pip install -e .) && netbox-restart"
+netbox-restart() {
+  netbox-stop && sleep 1 && netbox-run-bg
+}
+
+netbox-reload() {
+  cd "$PLUGIN_DIR" || return 1
+  if command -v uv >/dev/null 2>&1; then
+    uv pip install -e . || return 1
+  else
+    pip install -e . || return 1
+  fi
+  netbox-restart
+}
 
 alias netbox-logs="tail -f /tmp/netbox.log"
-alias netbox-status="[ -f /tmp/netbox.pid ] && kill -0 \$(cat /tmp/netbox.pid) 2>/dev/null && echo 'NetBox is running (PID: '\$(cat /tmp/netbox.pid)')' || echo 'NetBox is not running'; [ -f /tmp/rqworker.pid ] && kill -0 \$(cat /tmp/rqworker.pid) 2>/dev/null && echo 'RQ worker is running (PID: '\$(cat /tmp/rqworker.pid)')' || echo 'RQ worker is not running'"
 alias rq-logs="tail -f /tmp/rqworker.log"
-alias rq-status="[ -f /tmp/rqworker.pid ] && kill -0 \$(cat /tmp/rqworker.pid) 2>/dev/null && echo 'RQ worker is running (PID: '\$(cat /tmp/rqworker.pid)')' || echo 'RQ worker is not running'"
-alias netbox-shell="cd /opt/netbox/netbox && source /opt/netbox/venv/bin/activate && python manage.py shell"
-alias netbox-test="cd $PLUGIN_DIR && source /opt/netbox/venv/bin/activate && python -m pytest"
-alias netbox-manage="cd /opt/netbox/netbox && source /opt/netbox/venv/bin/activate && python manage.py"
-alias plugin-install="cd $PLUGIN_DIR && (command -v uv >/dev/null 2>&1 && uv pip install -e . || pip install -e .)"
-alias ruff-check="cd $PLUGIN_DIR && ruff check ."
-alias ruff-format="cd $PLUGIN_DIR && ruff format ."
-alias ruff-fix="cd $PLUGIN_DIR && ruff check --fix ."
-alias diagnose="$PLUGIN_DIR/.devcontainer/scripts/diagnose.sh"
-alias plugins-install='if [ -f "$PLUGIN_DIR/.devcontainer/extra-requirements.txt" ]; then source /opt/netbox/venv/bin/activate && pip install -r "$PLUGIN_DIR/.devcontainer/extra-requirements.txt"; else echo "No .devcontainer/extra-requirements.txt found"; fi'
+
+netbox-status() {
+  local PID
+  if [ -f /tmp/netbox.pid ]; then
+    PID=$(cat /tmp/netbox.pid 2>/dev/null)
+    if [ -n "$PID" ] && is_expected_pid "$PID" "python.*runserver.*8000"; then
+      echo "NetBox is running (PID: $PID)"
+    else
+      echo "NetBox is not running"
+    fi
+  else
+    echo "NetBox is not running"
+  fi
+  if [ -f /tmp/rqworker.pid ]; then
+    PID=$(cat /tmp/rqworker.pid 2>/dev/null)
+    if [ -n "$PID" ] && is_expected_pid "$PID" "python.*rqworker"; then
+      echo "RQ worker is running (PID: $PID)"
+    else
+      echo "RQ worker is not running"
+    fi
+  else
+    echo "RQ worker is not running"
+  fi
+}
+
+rq-status() {
+  local PID
+  if [ -f /tmp/rqworker.pid ]; then
+    PID=$(cat /tmp/rqworker.pid 2>/dev/null)
+    if [ -n "$PID" ] && is_expected_pid "$PID" "python.*rqworker"; then
+      echo "RQ worker is running (PID: $PID)"
+    else
+      echo "RQ worker is not running"
+    fi
+  else
+    echo "RQ worker is not running"
+  fi
+}
+
+netbox-shell() {
+  cd /opt/netbox/netbox && source /opt/netbox/venv/bin/activate && python manage.py shell
+}
+
+netbox-test() {
+  cd "$PLUGIN_DIR" && source /opt/netbox/venv/bin/activate && python -m pytest "$@"
+}
+
+netbox-manage() {
+  cd /opt/netbox/netbox && source /opt/netbox/venv/bin/activate && python manage.py "$@"
+}
+
+plugin-install() {
+  cd "$PLUGIN_DIR" || return 1
+  if command -v uv >/dev/null 2>&1; then
+    uv pip install -e .
+  else
+    pip install -e .
+  fi
+}
+
+plugins-install() {
+  if [ -f "$PLUGIN_DIR/.devcontainer/extra-requirements.txt" ]; then
+    source /opt/netbox/venv/bin/activate && pip install -r "$PLUGIN_DIR/.devcontainer/extra-requirements.txt"
+  else
+    echo "No .devcontainer/extra-requirements.txt found"
+  fi
+}
+
+ruff-check() { cd "$PLUGIN_DIR" && command ruff check .; }
+ruff-format() { cd "$PLUGIN_DIR" && command ruff format .; }
+ruff-fix()    { cd "$PLUGIN_DIR" && command ruff check --fix .; }
+
+diagnose() { "$PLUGIN_DIR/.devcontainer/scripts/diagnose.sh"; }
 
 # RQ job inspection commands
-alias rq-stats="cd /opt/netbox/netbox && source /opt/netbox/venv/bin/activate && python manage.py rqstats"
-alias rq-jobs="cd /opt/netbox/netbox && source /opt/netbox/venv/bin/activate && python manage.py shell -c \"from django_rq import get_queue; q = get_queue('default'); print(f'Jobs in queue: {len(q)}'); [print(f'  {job.id[:8]}: {job.func_name} - {job.get_status()}') for job in q.jobs[:10]]\""
-alias rq-failed="cd /opt/netbox/netbox && source /opt/netbox/venv/bin/activate && python manage.py shell -c \"from django_rq import get_failed_queue; q = get_failed_queue(); print(f'Failed jobs: {len(q)}'); [print(f'  {job.id[:8]}: {job.func_name}') for job in q.jobs[:10]]\""
-alias rq-recent="cd /opt/netbox/netbox && source /opt/netbox/venv/bin/activate && python manage.py shell -c \"from core.models import Job; jobs = Job.objects.all().order_by('-created')[:10]; [print(f'{j.id}: {j.name[:50]} - {getattr(j.status, \\\"value\\\", j.status)} ({j.user})') for j in jobs]\""
+rq-stats() {
+  cd /opt/netbox/netbox && source /opt/netbox/venv/bin/activate && python manage.py rqstats
+}
+
+rq-jobs() {
+  cd /opt/netbox/netbox && source /opt/netbox/venv/bin/activate && python manage.py shell -c \
+    "from django_rq import get_queue; q = get_queue('default'); print(f'Jobs in queue: {len(q)}'); [print(f'  {job.id[:8]}: {job.func_name} - {job.get_status()}') for job in q.jobs[:10]]"
+}
+
+rq-failed() {
+  cd /opt/netbox/netbox && source /opt/netbox/venv/bin/activate && python manage.py shell -c \
+    "from django_rq import get_failed_queue; q = get_failed_queue(); print(f'Failed jobs: {len(q)}'); [print(f'  {job.id[:8]}: {job.func_name}') for job in q.jobs[:10]]"
+}
+
+rq-recent() {
+  cd /opt/netbox/netbox && source /opt/netbox/venv/bin/activate && python manage.py shell -c \
+    "from core.models import Job; jobs = Job.objects.all().order_by('-created')[:10]; [print(f'{j.id}: {j.name[:50]} - {getattr(j.status, \"value\", j.status)} ({j.user})') for j in jobs]"
+}
 
 # Help
-alias dev-help='echo "🎯 NetBox LibreNMS Plugin Development Commands:"; echo ""; echo "📊 NetBox Server Management:"; echo "  netbox-run-bg       : Start NetBox in background"; echo "  netbox-run          : Start NetBox in foreground (for debugging)"; echo "  netbox-stop         : Stop NetBox and RQ worker"; echo "  netbox-restart      : Restart NetBox and RQ worker"; echo "  netbox-reload       : Reinstall plugin and restart NetBox"; echo "  netbox-status       : Check if NetBox and RQ worker are running"; echo "  netbox-logs         : View NetBox server logs"; echo ""; echo "⚙️  Background Jobs (RQ Worker):"; echo "  rq-status           : Check if RQ worker is running"; echo "  rq-logs             : View RQ worker logs"; echo "  rq-stats            : Show RQ queue statistics"; echo "  rq-jobs             : List jobs in default queue"; echo "  rq-failed           : List failed jobs"; echo "  rq-recent           : Show recent NetBox jobs"; echo ""; echo "🛠️  Development Tools:"; echo "  netbox-shell        : Open NetBox Django shell"; echo "  netbox-test         : Run plugin tests"; echo "  netbox-manage       : Run Django management commands"; echo "  plugin-install      : Reinstall plugin in development mode"; echo ""; echo "🧹 Code Quality:"; echo "  ruff-check          : Check code with Ruff"; echo "  ruff-format         : Format code with Ruff"; echo "  ruff-fix            : Auto-fix code issues with Ruff"; echo ""; echo "🔎 Diagnostics:"; echo "  diagnose            : Run startup diagnostics"; echo "  dev-help            : Show this help message"; echo ""; echo "📖 NetBox available at: http://localhost:8000 (admin/admin)"; echo ""'
+dev-help() {
+  echo "🎯 NetBox LibreNMS Plugin Development Commands:"
+  echo ""
+  echo "📊 NetBox Server Management:"
+  echo "  netbox-run-bg       : Start NetBox in background"
+  echo "  netbox-run          : Start NetBox in foreground (for debugging)"
+  echo "  netbox-stop         : Stop NetBox and RQ worker"
+  echo "  netbox-restart      : Restart NetBox and RQ worker"
+  echo "  netbox-reload       : Reinstall plugin and restart NetBox"
+  echo "  netbox-status       : Check if NetBox and RQ worker are running"
+  echo "  netbox-logs         : View NetBox server logs"
+  echo ""
+  echo "⚙️  Background Jobs (RQ Worker):"
+  echo "  rq-status           : Check if RQ worker is running"
+  echo "  rq-logs             : View RQ worker logs"
+  echo "  rq-stats            : Show RQ queue statistics"
+  echo "  rq-jobs             : List jobs in default queue"
+  echo "  rq-failed           : List failed jobs"
+  echo "  rq-recent           : Show recent NetBox jobs"
+  echo ""
+  echo "🛠️  Development Tools:"
+  echo "  netbox-shell        : Open NetBox Django shell"
+  echo "  netbox-test         : Run plugin tests"
+  echo "  netbox-manage       : Run Django management commands"
+  echo "  plugin-install      : Reinstall plugin in development mode"
+  echo ""
+  echo "🧹 Code Quality:"
+  echo "  ruff-check          : Check code with Ruff"
+  echo "  ruff-format         : Format code with Ruff"
+  echo "  ruff-fix            : Auto-fix code issues with Ruff"
+  echo ""
+  echo "🔎 Diagnostics:"
+  echo "  diagnose            : Run startup diagnostics"
+  echo "  dev-help            : Show this help message"
+  echo ""
+  echo "📖 NetBox available at: http://localhost:8000 (admin/admin)"
+}
 
 echo "✅ Aliases loaded! Try: rq-status, rq-stats, rq-recent, dev-help"

--- a/.devcontainer/scripts/process-helpers.sh
+++ b/.devcontainer/scripts/process-helpers.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Shared process management helpers.
+# Sourced by load-aliases.sh and start-netbox.sh.
+
+# Graceful termination: SIGTERM, wait, then SIGKILL if still alive.
+graceful_kill_pid() {
+  local pid="$1"
+  kill -15 "$pid" 2>/dev/null
+  sleep 2
+  kill -0 "$pid" 2>/dev/null && kill -9 "$pid" 2>/dev/null
+}
+
+graceful_kill_pattern() {
+  local pattern="$1"
+  pkill -15 -f "$pattern" 2>/dev/null
+  sleep 2
+  pgrep -f "$pattern" >/dev/null 2>&1 && pkill -9 -f "$pattern" 2>/dev/null
+}
+
+# Verify a PID matches the expected process before killing it
+is_expected_pid() {
+  local pid="$1" pattern="$2"
+  ps -p "$pid" -o args= 2>/dev/null | grep -Eq "$pattern"
+}

--- a/.devcontainer/scripts/setup.sh
+++ b/.devcontainer/scripts/setup.sh
@@ -29,6 +29,13 @@ detect_plugin_workspace() {
   fi
 }
 
+# Clean up empty CA bundle vars (Compose injects "" when host var is unset)
+for _ca_var in REQUESTS_CA_BUNDLE SSL_CERT_FILE CURL_CA_BUNDLE; do
+  _val="${!_ca_var}"
+  [ -z "$_val" ] && unset "$_ca_var"
+done
+unset _ca_var _val
+
 # Configure proxy for apt and pip if proxy environment variables are set
 if [ -n "$HTTP_PROXY" ] || [ -n "$HTTPS_PROXY" ]; then
   echo "🌐 Configuring proxy settings..."
@@ -187,7 +194,7 @@ if [ -f "$CONF_FILE" ]; then
       echo "import importlib.util, os";
       echo "PLUGINS = ['netbox_librenms_plugin']";
       echo "PLUGINS_CONFIG = {'netbox_librenms_plugin': {}}";
-      echo "_pc_path = '/workspaces/netbox-librenms-plugin/.devcontainer/config/plugin-config.py'";
+      echo "_pc_path = '$PLUGIN_WS_DIR/.devcontainer/config/plugin-config.py'";
       echo "if os.path.isfile(_pc_path):";
       echo "    _spec = importlib.util.spec_from_file_location('workspace_plugin_config', _pc_path)";
       echo "    _mod = importlib.util.module_from_spec(_spec)";
@@ -201,7 +208,7 @@ if [ -f "$CONF_FILE" ]; then
       echo "    print('ℹ️ plugin-config.py not found; using defaults')";
 
       echo "# Import optional extra NetBox configuration (uppercase settings)";
-      echo "_xc_path = '/workspaces/netbox-librenms-plugin/.devcontainer/config/extra-configuration.py'";
+      echo "_xc_path = '$PLUGIN_WS_DIR/.devcontainer/config/extra-configuration.py'";
       echo "if os.path.isfile(_xc_path):";
       echo "    _xc_spec = importlib.util.spec_from_file_location('workspace_extra_configuration', _xc_path)";
       echo "    _xc_mod = importlib.util.module_from_spec(_xc_spec)";
@@ -214,7 +221,7 @@ if [ -f "$CONF_FILE" ]; then
       echo "        print(f'⚠️  Failed to apply extra-configuration.py: {e}')";
 
       echo "# Import Codespaces configuration when applicable (uppercase settings)";
-      echo "_cs_path = '/workspaces/netbox-librenms-plugin/.devcontainer/config/codespaces-configuration.py'";
+      echo "_cs_path = '$PLUGIN_WS_DIR/.devcontainer/config/codespaces-configuration.py'";
       echo "if os.environ.get('CODESPACES') == 'true' and os.path.isfile(_cs_path):";
       echo "    _cs_spec = importlib.util.spec_from_file_location('workspace_codespaces_configuration', _cs_path)";
       echo "    _cs_mod = importlib.util.module_from_spec(_cs_spec)";
@@ -252,12 +259,14 @@ echo "🗃️  Applying database migrations..."
 python manage.py migrate 2>&1 | grep -E "(Operations to perform|Running migrations|Apply all migrations|No migrations to apply|\s+Applying|\s+OK)" || true
 
 echo "🔐 Creating superuser (if not exists)..."
+echo "   Credentials are read from environment variables (see .devcontainer/.env)"
 python manage.py shell -c "
+import os
 from django.contrib.auth import get_user_model
 User = get_user_model()
-username = '${SUPERUSER_NAME:-admin}'
-email = '${SUPERUSER_EMAIL:-admin@example.com}'
-password = '${SUPERUSER_PASSWORD:-admin}'
+username = (os.environ.get('SUPERUSER_NAME') or '').strip() or 'admin'
+email = (os.environ.get('SUPERUSER_EMAIL') or '').strip() or 'admin@example.com'
+password = (os.environ.get('SUPERUSER_PASSWORD') or '').strip() or 'admin'
 if not User.objects.filter(username=username).exists():
     User.objects.create_superuser(username, email, password)
     print(f'Created superuser: {username}')

--- a/.devcontainer/scripts/start-netbox.sh
+++ b/.devcontainer/scripts/start-netbox.sh
@@ -21,32 +21,33 @@ else
   ACCESS_URL="http://localhost:8000"
 fi
 
-# Kill any orphaned RQ workers (not tracked by PID file)
-echo "🧹 Cleaning up orphaned processes..."
-ORPHAN_RQ_PIDS=$(pgrep -f "python.*rqworker" 2>/dev/null)
-if [ -n "$ORPHAN_RQ_PIDS" ]; then
-  echo "   Found orphaned RQ workers, killing..."
-  pkill -15 -f "python.*rqworker" 2>/dev/null
-  sleep 2
-  pgrep -f "python.*rqworker" >/dev/null 2>&1 && pkill -9 -f "python.*rqworker" 2>/dev/null
-  sleep 1
+# Load shared process management helpers
+if ! source "$(dirname "$0")/process-helpers.sh"; then
+  echo "ERROR: Failed to load process-helpers.sh" >&2
+  exit 1
 fi
 
-# Kill any orphaned NetBox runserver processes
-ORPHAN_NETBOX_PIDS=$(pgrep -f "python.*runserver.*8000" 2>/dev/null)
-if [ -n "$ORPHAN_NETBOX_PIDS" ]; then
+# Kill any orphaned processes (not tracked by PID file)
+echo "🧹 Cleaning up orphaned processes..."
+if pgrep -f "python.*rqworker" >/dev/null 2>&1; then
+  echo "   Found orphaned RQ workers, killing..."
+  graceful_kill_pattern "python.*rqworker"
+fi
+
+if pgrep -f "python.*runserver.*8000" >/dev/null 2>&1; then
   echo "   Found orphaned NetBox servers, killing..."
-  pkill -15 -f "python.*runserver.*8000" 2>/dev/null
-  sleep 2
-  pgrep -f "python.*runserver.*8000" >/dev/null 2>&1 && pkill -9 -f "python.*runserver.*8000" 2>/dev/null
-  sleep 1
+  graceful_kill_pattern "python.*runserver.*8000"
 fi
 
 # Stop any tracked processes from PID files
 if [ -f /tmp/netbox.pid ]; then
   OLD_PID=$(cat /tmp/netbox.pid 2>/dev/null)
   if [ -n "$OLD_PID" ] && kill -0 "$OLD_PID" 2>/dev/null; then
-    kill "$OLD_PID" 2>/dev/null || kill -9 "$OLD_PID" 2>/dev/null
+    if is_expected_pid "$OLD_PID" "python.*runserver.*8000"; then
+      graceful_kill_pid "$OLD_PID"
+    else
+      echo "⚠️  Skipping stale /tmp/netbox.pid (PID $OLD_PID is not NetBox runserver)"
+    fi
   fi
   rm -f /tmp/netbox.pid
 fi
@@ -54,7 +55,11 @@ fi
 if [ -f /tmp/rqworker.pid ]; then
   OLD_PID=$(cat /tmp/rqworker.pid 2>/dev/null)
   if [ -n "$OLD_PID" ] && kill -0 "$OLD_PID" 2>/dev/null; then
-    kill "$OLD_PID" 2>/dev/null || kill -9 "$OLD_PID" 2>/dev/null
+    if is_expected_pid "$OLD_PID" "python.*rqworker"; then
+      graceful_kill_pid "$OLD_PID"
+    else
+      echo "⚠️  Skipping stale /tmp/rqworker.pid (PID $OLD_PID is not rqworker)"
+    fi
   fi
   rm -f /tmp/rqworker.pid
 fi

--- a/.devcontainer/scripts/welcome.sh
+++ b/.devcontainer/scripts/welcome.sh
@@ -7,7 +7,8 @@ source "$(dirname "$0")/load-aliases.sh" 2>/dev/null
 echo ""
 echo "🎯 NetBox LibreNMS Plugin Development Environment"
 
-if [ ! -f "/workspaces/netbox-librenms-plugin/.devcontainer/config/plugin-config.py" ]; then
+PLUGIN_WS_DIR="${PLUGIN_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
+if [ ! -f "$PLUGIN_WS_DIR/.devcontainer/config/plugin-config.py" ]; then
   echo ""
   echo "⚠️  Plugin configuration not found: .devcontainer/config/plugin-config.py"
   echo "   Create it first: cp .devcontainer/config/plugin-config.py.example .devcontainer/config/plugin-config.py"


### PR DESCRIPTION
## Summary
Hardens and refactors devcontainer shell scripts for robustness, portability, and maintainability.

## Motivation / Problem
- **Refactor / Maintenance**: The devcontainer scripts had several fragility issues — hardcoded paths, aliases that don't expand in non-interactive shells, PID kills without identity validation (risking killing recycled PIDs), `eval` usage for variable expansion, and duplicated helper functions across files.

## Scope of Change
- [x] Config / settings
- Other: DevContainer shell scripts (.devcontainer/scripts/)

## Changes
- Extract `graceful_kill_pid`, `graceful_kill_pattern`, `is_expected_pid` into shared `process-helpers.sh`, sourced by both `load-aliases.sh` and `start-netbox.sh` with fail-fast guards
- Convert aliases to functions for reliability in non-interactive shells; add `$@` passthrough on `netbox-test` and `netbox-manage`
- Compute `PLUGIN_DIR` from `BASH_SOURCE` instead of hardcoding `/workspaces/netbox-librenms-plugin`
- Validate PID identity before killing tracked processes (`netbox-stop`, `netbox-status`, `rq-status`) to prevent killing recycled PIDs
- Use explicit `if/else` for uv/pip fallback instead of short-circuit `||`
- Quote all variable expansions in `diagnose.sh` test commands
- Replace `eval` with bash indirect expansion (`${!var}`) for CA bundle cleanup
- Use two-phase SIGTERM→sleep→SIGKILL termination consistently
- Normalize superuser credentials via `os.environ` with `.strip()`

## How Was This Tested?
- [x] Manual testing

### Manual Test Steps
1. `bash -n` syntax check on all 6 scripts — all pass
2. Sourced `load-aliases.sh` and verified all functions are defined with correct `PLUGIN_DIR` resolution
3. Tested `is_expected_pid` against real processes — correctly matches expected, rejects wrong patterns, rejects dead PIDs
4. Tested fail-fast guards by hiding `process-helpers.sh` — both `load-aliases.sh` (return 1) and `start-netbox.sh` (exit 1) abort early with error messages

## Risk Assessment
- Does not affect existing users — changes are limited to devcontainer development environment scripts
- No impact on plugin sync/import logic

## Backwards Compatibility
- [x] No breaking changes
- Shell functions replace aliases with identical names — transparent to users

## Other Notes
- `netbox-logs` and `rq-logs` remain as aliases (simple `tail -f` one-liners)
- The `ruff-*` functions use `command ruff` to avoid infinite recursion