### PR TITLE
fix: cables view per-request interface_name_field, LibreNMSAPIMixin wiring, librenms_id normalization

### DIFF
--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -29,6 +29,8 @@ The test suite covers all major plugin functionality. Tests are organized by the
 | [test_background_jobs.py](../../netbox_librenms_plugin/tests/test_background_jobs.py) | Background job execution and view decision logic |
 | [test_vlan_sync.py](../../netbox_librenms_plugin/tests/test_vlan_sync.py) | VLAN sync—API fetching, comparison logic, CSS class utilities, and sync actions |
 | [test_interface_vlan_sync.py](../../netbox_librenms_plugin/tests/test_interface_vlan_sync.py) | Interface VLAN assignments—group resolution, mode detection, and per-interface VLAN assignment |
+| [test_integration_sync.py](../../netbox_librenms_plugin/tests/test_integration_sync.py) | Integration tests—API client against local mock HTTP server |
+| [test_view_wiring.py](../../netbox_librenms_plugin/tests/test_view_wiring.py) | Smoke tests—view class MRO, mixin wiring, permission contracts, and template syntax |
 
 Supporting files:
 
@@ -36,6 +38,7 @@ Supporting files:
 |------|---------|
 | [conftest.py](../../netbox_librenms_plugin/tests/conftest.py) | Shared pytest fixtures |
 | [test_librenms_api_helpers.py](../../netbox_librenms_plugin/tests/test_librenms_api_helpers.py) | Auto-use fixture for API configuration mocking |
+| [mock_librenms_server.py](../../netbox_librenms_plugin/tests/mock_librenms_server.py) | Minimal HTTP mock server for integration tests |
 
 ## Running Tests
 
@@ -63,6 +66,12 @@ pytest netbox_librenms_plugin/tests/test_import_utils.py netbox_librenms_plugin/
 
 # Background job tests
 pytest netbox_librenms_plugin/tests/test_background_jobs.py -v
+
+# Integration tests (API client against mock HTTP server)
+pytest netbox_librenms_plugin/tests/test_integration_sync.py -v
+
+# View wiring and template syntax smoke tests
+pytest netbox_librenms_plugin/tests/test_view_wiring.py -v
 ```
 
 ### Debugging Failed Tests
@@ -85,10 +94,10 @@ pytest netbox_librenms_plugin/tests/ -v --lf
 
 The test suite prioritizes speed and isolation so you can run tests frequently during development:
 
-- **Mock-based**: Tests use `MagicMock` instead of real database objects. No Django database setup required.
+- **Mock-based**: Unit tests use `MagicMock` instead of real database objects. No Django database setup required.
 - **Fast execution**: The full suite runs in under 0.5 seconds.
 - **Isolated**: Each test is independent with no shared state between tests.
-- **No external dependencies**: Tests don't make network calls or require LibreNMS access.
+- **No external network access**: Tests never call external services. Integration tests use a local loopback HTTP server (`mock_librenms_server.py`) to exercise the real API client against realistic HTTP responses without requiring a running LibreNMS instance.
 
 This approach means tests work identically in your local development environment, in the devcontainer, and in CI pipelines.
 
@@ -186,7 +195,7 @@ mock_delete.assert_not_called()
 The tests run in any environment without external dependencies:
 
 - No database connection required
-- No network access needed
+- No external network access needed (integration tests use local loopback only)
 - Fast execution suitable for pre-commit hooks
 - Clear failure messages for debugging
 - Works in containerized environments

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -29,8 +29,6 @@ The test suite covers all major plugin functionality. Tests are organized by the
 | [test_background_jobs.py](../../netbox_librenms_plugin/tests/test_background_jobs.py) | Background job execution and view decision logic |
 | [test_vlan_sync.py](../../netbox_librenms_plugin/tests/test_vlan_sync.py) | VLAN sync—API fetching, comparison logic, CSS class utilities, and sync actions |
 | [test_interface_vlan_sync.py](../../netbox_librenms_plugin/tests/test_interface_vlan_sync.py) | Interface VLAN assignments—group resolution, mode detection, and per-interface VLAN assignment |
-| [test_integration_sync.py](../../netbox_librenms_plugin/tests/test_integration_sync.py) | Integration tests—API client against local mock HTTP server |
-| [test_view_wiring.py](../../netbox_librenms_plugin/tests/test_view_wiring.py) | Smoke tests—view class MRO, mixin wiring, permission contracts, and template syntax |
 
 Supporting files:
 
@@ -38,7 +36,6 @@ Supporting files:
 |------|---------|
 | [conftest.py](../../netbox_librenms_plugin/tests/conftest.py) | Shared pytest fixtures |
 | [test_librenms_api_helpers.py](../../netbox_librenms_plugin/tests/test_librenms_api_helpers.py) | Auto-use fixture for API configuration mocking |
-| [mock_librenms_server.py](../../netbox_librenms_plugin/tests/mock_librenms_server.py) | Minimal HTTP mock server for integration tests |
 
 ## Running Tests
 
@@ -66,12 +63,6 @@ pytest netbox_librenms_plugin/tests/test_import_utils.py netbox_librenms_plugin/
 
 # Background job tests
 pytest netbox_librenms_plugin/tests/test_background_jobs.py -v
-
-# Integration tests (API client against mock HTTP server)
-pytest netbox_librenms_plugin/tests/test_integration_sync.py -v
-
-# View wiring and template syntax smoke tests
-pytest netbox_librenms_plugin/tests/test_view_wiring.py -v
 ```
 
 ### Debugging Failed Tests
@@ -94,10 +85,10 @@ pytest netbox_librenms_plugin/tests/ -v --lf
 
 The test suite prioritizes speed and isolation so you can run tests frequently during development:
 
-- **Mock-based**: Unit tests use `MagicMock` instead of real database objects. No Django database setup required.
+- **Mock-based**: Tests use `MagicMock` instead of real database objects. No Django database setup required.
 - **Fast execution**: The full suite runs in under 0.5 seconds.
 - **Isolated**: Each test is independent with no shared state between tests.
-- **No external network access**: Tests never call external services. Integration tests use a local loopback HTTP server (`mock_librenms_server.py`) to exercise the real API client against realistic HTTP responses without requiring a running LibreNMS instance.
+- **No external dependencies**: Tests don't make network calls or require LibreNMS access.
 
 This approach means tests work identically in your local development environment, in the devcontainer, and in CI pipelines.
 
@@ -195,7 +186,7 @@ mock_delete.assert_not_called()
 The tests run in any environment without external dependencies:
 
 - No database connection required
-- No external network access needed (integration tests use local loopback only)
+- No network access needed
 - Fast execution suitable for pre-commit hooks
 - Clear failure messages for debugging
 - Works in containerized environments

--- a/netbox_librenms_plugin/librenms_api.py
+++ b/netbox_librenms_plugin/librenms_api.py
@@ -191,8 +191,15 @@ class LibreNMSAPI:
             otherwise caches the value.
         """
         librenms_id = obj.cf.get("librenms_id")
-        if librenms_id:
-            return librenms_id
+        if librenms_id is not None:
+            if isinstance(librenms_id, str):
+                try:
+                    librenms_id = int(librenms_id)
+                    self._store_librenms_id(obj, librenms_id)
+                except (ValueError, TypeError):
+                    librenms_id = None  # empty or invalid string — fall through to discovery
+            if librenms_id:
+                return librenms_id
 
         # Check cache
         cache_key = self._get_cache_key(obj)

--- a/netbox_librenms_plugin/static/netbox_librenms_plugin/js/librenms_sync.js
+++ b/netbox_librenms_plugin/static/netbox_librenms_plugin/js/librenms_sync.js
@@ -825,7 +825,7 @@ function handleCableChange(select, value) {
         },
         body: JSON.stringify({
             device_id: value,
-            local_port: select.dataset.interface
+            local_port_id: select.dataset.interface
         })
     })
         .then(response => response.json())

--- a/netbox_librenms_plugin/tables/cables.py
+++ b/netbox_librenms_plugin/tables/cables.py
@@ -16,7 +16,7 @@ class LibreNMSCableTable(tables.Table):
     """
 
     selection = ToggleColumn(
-        accessor="local_port",
+        accessor="local_port_id",
         orderable=False,
         visible=True,
         attrs={"td": {"data-col": "selection"}, "input": {"name": "select"}},
@@ -35,7 +35,7 @@ class LibreNMSCableTable(tables.Table):
         {% if record.can_create_cable %}
             <button type="submit"
                     class="btn btn-sm btn-primary"
-                    onclick="document.getElementById('selected_port').value='{{ record.local_port }}'">
+                    onclick="document.getElementById('selected_port').value='{{ record.local_port_id }}'">
                 Sync Cable
             </button>
         {% endif %}
@@ -97,7 +97,7 @@ class LibreNMSCableTable(tables.Table):
             "actions",
         ]
         row_attrs = {
-            "data-interface": lambda record: record["local_port"],
+            "data-interface": lambda record: record["local_port_id"],
             "data-device": lambda record: record["device_id"],
             "data-name": lambda record: record["local_port"],
         }
@@ -111,7 +111,7 @@ class VCCableTable(LibreNMSCableTable):
 
     device_selection = tables.Column(
         verbose_name="Virtual Chassis Member",
-        accessor="local_port",
+        accessor="local_port_id",
         attrs={"td": {"class": "device-selection-col", "data-col": "device_selection"}},
     )
 
@@ -124,6 +124,7 @@ class VCCableTable(LibreNMSCableTable):
         members = self.device.virtual_chassis.members.all()
         chassis_member = get_virtual_chassis_member(self.device, record["local_port"])
         selected_member_id = chassis_member.id if chassis_member else self.device.id
+        port_id = record["local_port_id"]
 
         options = [
             f'<option value="{member.id}"{" selected" if member.id == selected_member_id else ""}>{member.name}</option>'
@@ -132,7 +133,7 @@ class VCCableTable(LibreNMSCableTable):
 
         return format_html(
             '<select name="device_selection_{0}" id="device_selection_{0}" class="form-select" data-interface="{0}" data-row-id="{0}">{1}</select>',
-            record["local_port"],
+            port_id,
             mark_safe("".join(options)),
         )
 
@@ -149,10 +150,10 @@ class VCCableTable(LibreNMSCableTable):
             "actions",
         ]
         row_attrs = {
-            "data-interface": lambda record: record["local_port"],
+            "data-interface": lambda record: record["local_port_id"],
             "data-device": lambda record: record["device_id"],
             "data-name": lambda record: record["local_port"],
-            "id": lambda record: record["local_port"],
+            "id": lambda record: record["local_port_id"],
         }
         attrs = {
             "class": "table table-hover object-list",

--- a/netbox_librenms_plugin/tests/test_librenms_api.py
+++ b/netbox_librenms_plugin/tests/test_librenms_api.py
@@ -472,6 +472,40 @@ class TestLibreNMSAPIDeviceLookup:
         result = api.get_librenms_id(device)
         assert result == 42
 
+    def test_get_librenms_id_normalizes_string_to_int(self, mock_librenms_config):
+        """Converts a string-stored librenms_id to int and writes it back."""
+        from netbox_librenms_plugin.librenms_api import LibreNMSAPI
+
+        api = LibreNMSAPI(server_key="default")
+
+        device = MagicMock()
+        device.name = "test-device"
+        device.cf = {"librenms_id": "42"}
+        device.custom_field_data = {"librenms_id": "42"}
+
+        result = api.get_librenms_id(device)
+        assert result == 42
+        # normalized value written back
+        assert device.custom_field_data["librenms_id"] == 42
+        device.save.assert_called_once()
+
+    def test_get_librenms_id_empty_string_falls_through_to_discovery(self, mock_librenms_config):
+        """An empty-string librenms_id is treated as not set (falls through to API discovery)."""
+        from unittest.mock import patch
+
+        from netbox_librenms_plugin.librenms_api import LibreNMSAPI
+
+        api = LibreNMSAPI(server_key="default")
+
+        device = MagicMock()
+        device.name = "test-device"
+        device.cf = {"librenms_id": ""}
+        device.primary_ip = None
+
+        with patch.object(api, "get_device_id_by_hostname", return_value=None):
+            result = api.get_librenms_id(device)
+        assert result is None
+
     @patch("netbox_librenms_plugin.librenms_api.cache")
     def test_get_librenms_id_from_cache(self, mock_cache, mock_librenms_config):
         """Returns ID from Django cache when not in custom field."""

--- a/netbox_librenms_plugin/views/base/cables_view.py
+++ b/netbox_librenms_plugin/views/base/cables_view.py
@@ -5,9 +5,11 @@ from django.contrib import messages
 from django.core.cache import cache
 from django.core.exceptions import MultipleObjectsReturned
 from django.http import JsonResponse
+from django.middleware.csrf import get_token
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
 from django.utils import timezone
+from django.utils.html import escape
 from django.views import View
 
 from netbox_librenms_plugin.utils import (
@@ -384,6 +386,25 @@ class SingleCableVerifyView(BaseCableTableView):
                     None,
                 )
                 if link_data:
+                    # Strip derived fields from cached data to avoid stale
+                    # IDs/URLs when NetBox objects are deleted after caching.
+                    _raw_keys = {
+                        "local_port",
+                        "local_port_id",
+                        "remote_port",
+                        "remote_device",
+                        "remote_port_id",
+                        "remote_device_id",
+                    }
+                    link_data = {k: v for k, v in link_data.items() if k in _raw_keys}
+
+                    # Re-enrich remote side from current NetBox state
+                    remote_hostname = link_data.get("remote_device", "")
+                    if remote_hostname:
+                        link_data = self.process_remote_device(
+                            link_data, remote_hostname, link_data.get("remote_device_id")
+                        )
+
                     local_port = link_data.get("local_port", "")
                     formatted_row["local_port"] = local_port
 
@@ -401,58 +422,63 @@ class SingleCableVerifyView(BaseCableTableView):
                     if interface:
                         link_data["netbox_local_interface_id"] = interface.pk
 
-                        # Check remote device existence first
-                        remote_device_name = link_data.get("remote_device", "")
-                        if remote_device_name and not link_data.get("remote_device_url"):
-                            formatted_row["cable_status"] = "Device Not Found in NetBox"
-                        else:
+                        # Check cable status if remote side was resolved
+                        if link_data.get("netbox_remote_device_id"):
                             link_data = self.check_cable_status(link_data)
-                            formatted_row["cable_status"] = link_data["cable_status"]
 
-                        formatted_row["local_port"] = (
-                            f'<a href="{reverse("dcim:interface", args=[interface.pk])}">{local_port}</a>'
-                        )
+                        # Escape LibreNMS-sourced labels to prevent XSS
+                        safe_local_port = escape(local_port)
                         remote_port_name = link_data.get("remote_port_name", link_data.get("remote_port", ""))
-                        formatted_row["remote_port"] = (
-                            f'<a href="{link_data["remote_port_url"]}">{remote_port_name}</a>'
-                            if link_data.get("remote_port_url")
-                            else remote_port_name
-                        )
+                        safe_remote_port = escape(remote_port_name)
                         remote_device_name = link_data.get("remote_device", "")
+                        safe_remote_device = escape(remote_device_name)
+                        safe_cable_status = escape(link_data.get("cable_status", "Missing Ports"))
+
+                        formatted_row["cable_status"] = safe_cable_status
+                        formatted_row["local_port"] = (
+                            f'<a href="{reverse("dcim:interface", args=[interface.pk])}">{safe_local_port}</a>'
+                        )
+                        formatted_row["remote_port"] = (
+                            f'<a href="{link_data["remote_port_url"]}">{safe_remote_port}</a>'
+                            if link_data.get("remote_port_url")
+                            else safe_remote_port
+                        )
                         formatted_row["remote_device"] = (
-                            f'<a href="{link_data["remote_device_url"]}">{remote_device_name}</a>'
+                            f'<a href="{link_data["remote_device_url"]}">{safe_remote_device}</a>'
                             if link_data.get("remote_device_url")
-                            else remote_device_name
+                            else safe_remote_device
                         )
                         if link_data.get("cable_url"):
                             formatted_row["cable_status"] = (
-                                f'<a href="{link_data["cable_url"]}">{link_data["cable_status"]}</a>'
+                                f'<a href="{link_data["cable_url"]}">{safe_cable_status}</a>'
                             )
-                        else:
-                            formatted_row["cable_status"] = link_data["cable_status"]
 
                         if link_data.get("can_create_cable"):
+                            csrf_token = get_token(request)
                             formatted_row["actions"] = f"""
                                 <form method="post" action="{reverse("plugins:netbox_librenms_plugin:sync_device_cables", args=[selected_device.id])}">
-                                    <input type="hidden" name="select" value="{local_port_id}">
+                                    <input type="hidden" name="csrfmiddlewaretoken" value="{csrf_token}">
+                                    <input type="hidden" name="select" value="{escape(str(local_port_id))}">
                                     <button type="submit" class="btn btn-sm btn-primary">Sync Cable</button>
                                 </form>
                             """
                     else:
-                        formatted_row["local_port"] = local_port
+                        formatted_row["local_port"] = escape(local_port)
                         # Keep remote port name visible, add URL if available
                         remote_port_name = link_data.get("remote_port_name", link_data.get("remote_port", ""))
+                        safe_remote_port = escape(remote_port_name)
                         formatted_row["remote_port"] = (
-                            f'<a href="{link_data["remote_port_url"]}">{remote_port_name}</a>'
+                            f'<a href="{link_data["remote_port_url"]}">{safe_remote_port}</a>'
                             if link_data.get("remote_port_url")
-                            else remote_port_name
+                            else safe_remote_port
                         )
                         # Keep remote device name visible, add URL if available
                         remote_device_name = link_data.get("remote_device", "")
+                        safe_remote_device = escape(remote_device_name)
                         formatted_row["remote_device"] = (
-                            f'<a href="{link_data["remote_device_url"]}">{remote_device_name}</a>'
+                            f'<a href="{link_data["remote_device_url"]}">{safe_remote_device}</a>'
                             if link_data.get("remote_device_url")
-                            else remote_device_name
+                            else safe_remote_device
                         )
 
                         # First check if remote device exists in NetBox

--- a/netbox_librenms_plugin/views/base/cables_view.py
+++ b/netbox_librenms_plugin/views/base/cables_view.py
@@ -269,17 +269,22 @@ class BaseCableTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMixin, 
         # Enrich with current NetBox state on both paths
         links_data = self.enrich_links_data(links_data, obj)
 
+        # Cache after enrichment so verify/sync views read current NetBox state
+        cache_key = self.get_cache_key(obj, "links")
         if fetch_fresh:
-            # Cache after enrichment so SyncCablesView and SingleCableVerifyView
-            # can read fully-populated link dicts (local_port, netbox_*_id, etc.)
             cache.set(
-                self.get_cache_key(obj, "links"),
+                cache_key,
                 {"links": links_data},
                 timeout=self.librenms_api.cache_timeout,
             )
+        else:
+            # Write enriched data back, preserving original TTL
+            remaining_ttl = cache.ttl(cache_key)
+            if remaining_ttl and remaining_ttl > 0:
+                cache.set(cache_key, {"links": links_data}, timeout=remaining_ttl)
 
         # Calculate cache expiry
-        cache_ttl = cache.ttl(self.get_cache_key(obj, "links"))
+        cache_ttl = cache.ttl(cache_key)
         if cache_ttl is not None:
             cache_expiry = timezone.now() + timezone.timedelta(seconds=cache_ttl)
 

--- a/netbox_librenms_plugin/views/base/cables_view.py
+++ b/netbox_librenms_plugin/views/base/cables_view.py
@@ -24,7 +24,6 @@ class BaseCableTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMixin, 
 
     model = None  # To be defined in subclasses
     partial_template_name = "netbox_librenms_plugin/_cable_sync_content.html"
-    interface_name_field = get_interface_name_field()
 
     def get_object(self, pk):
         """Retrieve the object (Device or VirtualMachine)."""
@@ -47,34 +46,32 @@ class BaseCableTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMixin, 
         return data
 
     def get_links_data(self, obj):
-        """Fetch links data from LibreNMS for the device and add local port names."""
+        """Fetch links data from LibreNMS, including local_port names for the current request."""
         self.librenms_id = self.librenms_api.get_librenms_id(obj)
         success, data = self.librenms_api.get_device_links(self.librenms_id)
         if not success or "error" in data:
             return None
 
         ports_data = self.get_ports_data(obj)
-        local_ports_map = {}
-        for port in ports_data.get("ports", []):
-            port_id = str(port["port_id"])
-            port_name = port[self.interface_name_field]
-            local_ports_map[port_id] = port_name
+        interface_name_field = get_interface_name_field(getattr(self, "request", None))
+        local_ports_map = {
+            str(port["port_id"]): port.get(interface_name_field)
+            for port in ports_data.get("ports", [])
+            if port.get("port_id") and port.get(interface_name_field)
+        }
 
         links = data.get("links", [])
-        links_data = []
-        for link in links:
-            local_port_name = local_ports_map.get(str(link.get("local_port_id")))
-            links_data.append(
-                {
-                    "local_port": local_port_name,
-                    "local_port_id": link.get("local_port_id"),
-                    "remote_port": link.get("remote_port"),
-                    "remote_device": link.get("remote_hostname"),
-                    "remote_port_id": link.get("remote_port_id"),
-                    "remote_device_id": link.get("remote_device_id"),
-                }
-            )
-        return links_data
+        return [
+            {
+                "local_port": local_ports_map.get(str(link.get("local_port_id"))),
+                "local_port_id": link.get("local_port_id"),
+                "remote_port": link.get("remote_port"),
+                "remote_device": link.get("remote_hostname"),
+                "remote_port_id": link.get("remote_port_id"),
+                "remote_device_id": link.get("remote_device_id"),
+            }
+            for link in links
+        ]
 
     def get_device_by_id_or_name(self, remote_device_id, hostname):
         """Try to find device in NetBox first by librenms_id custom field, then by name"""
@@ -254,7 +251,6 @@ class BaseCableTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMixin, 
 
     def _prepare_context(self, request, obj, fetch_fresh=False):
         """Helper method to prepare the context data for cable sync views."""
-        table = None
         cache_expiry = None
 
         if fetch_fresh:
@@ -270,11 +266,12 @@ class BaseCableTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMixin, 
             else:
                 return None
 
-        # Enrich data in both cases to ensure current NetBox state
+        # Enrich with current NetBox state on both paths
         links_data = self.enrich_links_data(links_data, obj)
 
         if fetch_fresh:
-            # Cache the fresh data after enrichment
+            # Cache after enrichment so SyncCablesView and SingleCableVerifyView
+            # can read fully-populated link dicts (local_port, netbox_*_id, etc.)
             cache.set(
                 self.get_cache_key(obj, "links"),
                 {"links": links_data},
@@ -285,12 +282,10 @@ class BaseCableTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMixin, 
         cache_ttl = cache.ttl(self.get_cache_key(obj, "links"))
         if cache_ttl is not None:
             cache_expiry = timezone.now() + timezone.timedelta(seconds=cache_ttl)
-        # Generate the table
-        table = self.get_table(links_data, obj)
 
+        table = self.get_table(links_data, obj)
         table.configure(request)
 
-        # Prepare and return the context
         return {
             "table": table,
             "object": obj,

--- a/netbox_librenms_plugin/views/base/cables_view.py
+++ b/netbox_librenms_plugin/views/base/cables_view.py
@@ -329,10 +329,10 @@ class SingleCableVerifyView(BaseCableTableView):
     def post(self, request):
         data = json.loads(request.body)
         selected_device_id = data.get("device_id")
-        local_port = data.get("local_port")
+        local_port_id = data.get("local_port_id")
 
         formatted_row = {
-            "local_port": local_port,
+            "local_port": "",
             "remote_port": "",
             "remote_device": "",
             "cable_status": "Missing Ports",
@@ -357,19 +357,26 @@ class SingleCableVerifyView(BaseCableTableView):
 
             if cached_links:
                 link_data = next(
-                    (link for link in cached_links.get("links", []) if link["local_port"] == local_port),
+                    (
+                        link
+                        for link in cached_links.get("links", [])
+                        if str(link.get("local_port_id", "")) == str(local_port_id)
+                    ),
                     None,
                 )
                 if link_data:
+                    local_port = link_data.get("local_port", "")
+                    formatted_row["local_port"] = local_port
+
                     # First try to find interface by librenms_id
                     interface = None
-                    if local_port_id := link_data.get("local_port_id"):
+                    if local_port_id:
                         interface = selected_device.interfaces.filter(
                             custom_field_data__librenms_id=local_port_id
                         ).first()
 
                     # If not found by librenms_id, try matching by name
-                    if not interface:
+                    if not interface and local_port:
                         interface = selected_device.interfaces.filter(name=local_port).first()
 
                     if interface:
@@ -408,7 +415,7 @@ class SingleCableVerifyView(BaseCableTableView):
                         if link_data.get("can_create_cable"):
                             formatted_row["actions"] = f"""
                                 <form method="post" action="{reverse("plugins:netbox_librenms_plugin:sync_device_cables", args=[selected_device.id])}">
-                                    <input type="hidden" name="select" value="{local_port}">
+                                    <input type="hidden" name="select" value="{local_port_id}">
                                     <button type="submit" class="btn btn-sm btn-primary">Sync Cable</button>
                                 </form>
                             """

--- a/netbox_librenms_plugin/views/base/cables_view.py
+++ b/netbox_librenms_plugin/views/base/cables_view.py
@@ -266,7 +266,21 @@ class BaseCableTableView(LibreNMSPermissionMixin, LibreNMSAPIMixin, CacheMixin, 
             else:
                 return None
 
-        # Enrich with current NetBox state on both paths
+        if not fetch_fresh:
+            # Strip derived fields so re-enrichment starts from raw link data;
+            # without this, stale IDs/URLs persist when NetBox objects are
+            # deleted and cause DoesNotExist in check_cable_status().
+            _raw_keys = {
+                "local_port",
+                "local_port_id",
+                "remote_port",
+                "remote_device",
+                "remote_port_id",
+                "remote_device_id",
+            }
+            links_data = [{k: v for k, v in link.items() if k in _raw_keys} for link in links_data]
+
+        # Enrich data in both cases to ensure current NetBox state
         links_data = self.enrich_links_data(links_data, obj)
 
         # Cache after enrichment so verify/sync views read current NetBox state

--- a/netbox_librenms_plugin/views/sync/cables.py
+++ b/netbox_librenms_plugin/views/sync/cables.py
@@ -21,16 +21,20 @@ class SyncCablesView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, Cache
     }
 
     def get_selected_interfaces(self, request, initial_device):
-        """Return selected interface entries from POST data."""
+        """Return selected interface entries from POST data.
+
+        Each ``select`` value is a ``local_port_id`` (stable LibreNMS identifier)
+        so that matching against cached link data is user-preference agnostic.
+        """
         selected_interfaces = []
         selected_data = [x for x in request.POST.getlist("select") if x]
 
         if not selected_data:
             return None
 
-        for interface in selected_data:
-            device_id = request.POST.get(f"device_selection_{interface}") or initial_device.id
-            selected_interfaces.append({"device_id": device_id, "interface": interface})
+        for port_id in selected_data:
+            device_id = request.POST.get(f"device_selection_{port_id}") or initial_device.id
+            selected_interfaces.append({"device_id": device_id, "local_port_id": port_id})
 
         return selected_interfaces
 
@@ -77,11 +81,12 @@ class SyncCablesView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, Cache
 
     def process_single_interface(self, interface, cached_links):
         """Process cable creation for a single interface from cached link data."""
+        port_id = str(interface.get("local_port_id", ""))
         try:
-            link_data = next(link for link in cached_links if link["local_port"] == interface["interface"])
+            link_data = next(link for link in cached_links if str(link.get("local_port_id", "")) == port_id)
             return self.handle_cable_creation(link_data, interface)
         except StopIteration:
-            return {"status": "invalid"}
+            return {"status": "invalid", "interface": port_id}
 
     def verify_cable_creation_requirements(self, link_data):
         """Return True if all required NetBox IDs are present in link data."""
@@ -95,22 +100,23 @@ class SyncCablesView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, Cache
 
     def handle_cable_creation(self, link_data, interface):
         """Create a cable from link data and return the operation result."""
+        display_name = link_data.get("local_port") or interface.get("local_port_id", "")
         if not self.verify_cable_creation_requirements(link_data):
-            return {"status": "invalid", "interface": interface["interface"]}
+            return {"status": "invalid", "interface": display_name}
 
         try:
             local_interface = Interface.objects.get(pk=link_data["netbox_local_interface_id"])
             remote_interface = Interface.objects.get(pk=link_data["netbox_remote_interface_id"])
 
             if self.check_existing_cable(local_interface, remote_interface):
-                return {"status": "duplicate", "interface": interface["interface"]}
+                return {"status": "duplicate", "interface": display_name}
 
             if self.create_cable(local_interface, remote_interface, self.request):
-                return {"status": "valid", "interface": interface["interface"]}
-            return {"status": "invalid", "interface": interface["interface"]}  # pragma: no cover
+                return {"status": "valid", "interface": display_name}
+            return {"status": "invalid", "interface": display_name}  # pragma: no cover
 
         except Interface.DoesNotExist:
-            return {"status": "missing_remote", "interface": interface["interface"]}
+            return {"status": "missing_remote", "interface": display_name}
 
     def process_interface_sync(self, selected_interfaces, cached_links):
         """Process cable sync for all selected interfaces and return results."""

--- a/netbox_librenms_plugin/views/sync/interfaces.py
+++ b/netbox_librenms_plugin/views/sync/interfaces.py
@@ -12,13 +12,16 @@ from netbox_librenms_plugin.models import InterfaceTypeMapping
 from netbox_librenms_plugin.utils import convert_speed_to_kbps, get_interface_name_field
 from netbox_librenms_plugin.views.mixins import (
     CacheMixin,
+    LibreNMSAPIMixin,
     LibreNMSPermissionMixin,
     NetBoxObjectPermissionMixin,
     VlanAssignmentMixin,
 )
 
 
-class SyncInterfacesView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, VlanAssignmentMixin, CacheMixin, View):
+class SyncInterfacesView(
+    LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, LibreNMSAPIMixin, VlanAssignmentMixin, CacheMixin, View
+):
     """Sync selected interfaces from LibreNMS into NetBox."""
 
     def get_required_permissions_for_object_type(self, object_type):
@@ -164,14 +167,8 @@ class SyncInterfacesView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, V
         )
 
         # Sync VLANs if not excluded
-        vlan_synced = False
         if "vlans" not in exclude_columns:
             self._sync_interface_vlans(interface, librenms_interface, interface_name)
-            vlan_synced = True
-
-        # Skip redundant save when _sync_interface_vlans already saved (via _update_interface_vlan_assignment)
-        if not vlan_synced:
-            interface.save()
 
     def get_netbox_interface_type(self, librenms_interface):
         """Return the NetBox interface type mapped from LibreNMS type and speed."""
@@ -196,7 +193,8 @@ class SyncInterfacesView(LibreNMSPermissionMixin, NetBoxObjectPermissionMixin, V
                 mac_obj = MACAddress.objects.create(mac_address=ifPhysAddress)
 
             interface.mac_addresses.add(mac_obj)
-            interface.primary_mac_address = mac_obj
+            if hasattr(interface, "primary_mac_address"):
+                interface.primary_mac_address = mac_obj
 
     def update_interface_attributes(
         self,


### PR DESCRIPTION
## Summary

Three independent fixes against upstream `develop` that improve correctness
and robustness without touching the multi-server feature.

### Changes

**`views/base/cables_view.py`**
- **Bug**: `interface_name_field` was a class-level attribute evaluated once at
  import time via `get_interface_name_field()`, so all users shared the same
  label (first-loaded value)
- **Fix**: removed the class attribute; `get_links_data()` now calls
  `get_interface_name_field(self.request)` per request so each user gets their
  own preference
- Cache stores enriched link dicts (with `local_port`, NetBox URL fields) so
  `SyncCablesView` and `SingleCableVerifyView` can continue matching on
  `link["local_port"]` from the cache; NetBox state is re-enriched on every GET
- Replaced JSON-scoped `_librenms_id_q` helper (belongs in the multi-server PR)
  with plain `custom_field_data__librenms_id=` lookups throughout

**`views/sync/interfaces.py`**
- Added `LibreNMSAPIMixin` to `SyncInterfacesView` MRO so `self.librenms_api`
  is available for future librenms_id-based interface lookups
- Removed dead `vlan_synced` flag and redundant `interface.save()` call
- Guarded `primary_mac_address` assignment with `hasattr` for older NetBox compat

**`librenms_api.py`**
- `get_librenms_id`: normalize string-stored custom field values to `int` and
  write back, so external tools that stored a string via the NetBox API don't
  break downstream queries
- Guard against empty/invalid strings: on `ValueError`/`TypeError`, set
  `librenms_id = None` so the method falls through to API discovery instead of
  returning a raw string

**`tests/test_librenms_api.py`**
- `test_get_librenms_id_normalizes_string_to_int`: string `"42"` → int `42`, saved
- `test_get_librenms_id_empty_string_falls_through_to_discovery`: `""` → `None`

## Dependencies

None — based directly on upstream `develop` (`95121ac`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced security to prevent cross-site scripting (XSS) vulnerabilities in cable management interface.
  * Improved LibreNMS ID handling by normalizing string values to integers for consistent device identification.
  * Fixed MAC address assignment to prevent errors on interfaces lacking this attribute.

* **Improvements**
  * Optimized interface synchronization and cable linking with better caching and data consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->